### PR TITLE
Move some functions to a separate core package

### DIFF
--- a/goose_std.go
+++ b/goose_std.go
@@ -2,8 +2,6 @@ package std
 
 import (
 	"sync"
-
-	"github.com/goose-lang/primitive"
 )
 
 // Assert(b) panics if b doesn't hold
@@ -51,35 +49,6 @@ func SliceSplit[T any](xs []T, n uint64) ([]T, []T) {
 	// (this would reset xs to have no extra capacity), but Goose doesn't
 	// support that.
 	return xs[:n], xs[n:]
-}
-
-// Returns true if x + y does not overflow
-func SumNoOverflow(x uint64, y uint64) bool {
-	return x+y >= x
-}
-
-// SumAssumeNoOverflow returns x + y, `Assume`ing that this does not overflow.
-//
-// *Use with care* - if the assumption is violated this function will panic.
-func SumAssumeNoOverflow(x uint64, y uint64) uint64 {
-	primitive.Assume(SumNoOverflow(x, y))
-	return x + y
-}
-
-// MulNoOverflow returns true if x * y does not overflow
-func MulNoOverflow(x uint64, y uint64) bool {
-	if x == 0 || y == 0 {
-		return true
-	}
-	return x <= (1<<64-1)/y
-}
-
-// MulAssumeNoOverflow returns x * y, `Assume`ing that this does not overflow.
-//
-// *Use with care* - if the assumption is violated this function will panic.
-func MulAssumeNoOverflow(x uint64, y uint64) uint64 {
-	primitive.Assume(MulNoOverflow(x, y))
-	return x * y
 }
 
 // JoinHandle is a mechanism to wait for a goroutine to finish. Calling `Join()`
@@ -174,27 +143,3 @@ func Multipar(num uint64, op func(uint64)) {
 // is a simple way to do so - the model always requires one step to reduce this
 // application to a value.
 func Skip() {}
-
-// Shuffle shuffles the elements of xs in place, using a Fisher-Yates shuffle.
-func Shuffle(xs []uint64) {
-	if len(xs) == 0 {
-		return
-	}
-	for i := uint64(len(xs) - 1); i > 0; i-- {
-		j := primitive.RandomUint64() % uint64(i+1)
-		temp := xs[i]
-		xs[i] = xs[j]
-		xs[j] = temp
-	}
-}
-
-// Permutation returns a random permutation of the integers 0, ..., n-1, using a
-// Fisher-Yates shuffle.
-func Permutation(n uint64) []uint64 {
-	order := make([]uint64, n)
-	for i := uint64(0); i < n; i++ {
-		order[i] = uint64(i)
-	}
-	Shuffle(order)
-	return order
-}

--- a/goose_std_test.go
+++ b/goose_std_test.go
@@ -58,47 +58,6 @@ func TestSliceSplit(t *testing.T) {
 	assert.Len(s2, 0)
 }
 
-func TestSumNoOverflow(t *testing.T) {
-	assert := assert.New(t)
-
-	assert.Equal(true, SumNoOverflow(2, 3))
-	assert.Equal(true, SumNoOverflow(1<<64-2, 1))
-	assert.Equal(true, SumNoOverflow(1, 1<<64-2))
-
-	assert.Equal(false, SumNoOverflow(1<<64-1, 1))
-	assert.Equal(false, SumNoOverflow(1<<63, 1<<63))
-	assert.Equal(false, SumNoOverflow(1<<64-7, 26))
-}
-
-func TestSumAssumeNoOverflow(t *testing.T) {
-	assert := assert.New(t)
-
-	assert.Equal(uint64(5), SumAssumeNoOverflow(2, 3))
-	assert.Equal(uint64(5), SumAssumeNoOverflow(5, 0))
-	assert.Equal(uint64(1<<64-1), SumAssumeNoOverflow(1<<64-2, 1))
-	assert.Panics(func() {
-		SumAssumeNoOverflow(1<<63, 1<<63)
-	})
-	assert.Panics(func() {
-		SumAssumeNoOverflow(1<<64-1, 2)
-	})
-}
-
-func TestMulAssumeNoOverflow(t *testing.T) {
-	assert := assert.New(t)
-
-	assert.Equal(uint64(6), MulAssumeNoOverflow(2, 3))
-	assert.Equal(uint64(0), MulAssumeNoOverflow(0, 3))
-	assert.Equal(uint64(1<<64-1), MulAssumeNoOverflow(1<<32-1, 1<<32+1))
-	assert.Equal(uint64(1<<64-1), MulAssumeNoOverflow(1<<32+1, 1<<32-1))
-	assert.Panics(func() {
-		MulAssumeNoOverflow(1<<63, 2)
-	})
-	assert.Panics(func() {
-		MulAssumeNoOverflow(2, 1<<63)
-	})
-}
-
 func TestMultipar(t *testing.T) {
 	ch := make(chan uint64)
 	go Multipar(5, func(i uint64) {
@@ -114,28 +73,4 @@ func TestMultipar(t *testing.T) {
 func TestSkip(t *testing.T) {
 	// nothing much to test, it does nothing
 	Skip()
-}
-
-func TestPermutation(t *testing.T) {
-	assert := assert.New(t)
-
-	order := Permutation(1)
-	assert.ElementsMatch(order, []uint64{0})
-
-	order = Permutation(2)
-	assert.ElementsMatch(order, []uint64{0, 1})
-
-	order = Permutation(5)
-	assert.ElementsMatch(order, []uint64{0, 1, 2, 3, 4})
-}
-
-func TestShuffle(t *testing.T) {
-	assert := assert.New(t)
-
-	xs := []uint64{}
-	Shuffle(xs)
-
-	xs = []uint64{1, 1, 1}
-	Shuffle(xs)
-	assert.Equal(xs, []uint64{1, 1, 1})
 }

--- a/std_core/std_core.go
+++ b/std_core/std_core.go
@@ -1,0 +1,59 @@
+// std_core is a subset of std that uses very little of the goose model
+//
+// It is used for bootstrapping goose.
+package std_core
+
+import "github.com/goose-lang/primitive"
+
+// Returns true if x + y does not overflow
+func SumNoOverflow(x uint64, y uint64) bool {
+	return x+y >= x
+}
+
+// SumAssumeNoOverflow returns x + y, `Assume`ing that this does not overflow.
+//
+// *Use with care* - if the assumption is violated this function will panic.
+func SumAssumeNoOverflow(x uint64, y uint64) uint64 {
+	primitive.Assume(SumNoOverflow(x, y))
+	return x + y
+}
+
+// MulNoOverflow returns true if x * y does not overflow
+func MulNoOverflow(x uint64, y uint64) bool {
+	if x == 0 || y == 0 {
+		return true
+	}
+	return x <= (1<<64-1)/y
+}
+
+// MulAssumeNoOverflow returns x * y, `Assume`ing that this does not overflow.
+//
+// *Use with care* - if the assumption is violated this function will panic.
+func MulAssumeNoOverflow(x uint64, y uint64) uint64 {
+	primitive.Assume(MulNoOverflow(x, y))
+	return x * y
+}
+
+// Shuffle shuffles the elements of xs in place, using a Fisher-Yates shuffle.
+func Shuffle(xs []uint64) {
+	if len(xs) == 0 {
+		return
+	}
+	for i := uint64(len(xs) - 1); i > 0; i-- {
+		j := primitive.RandomUint64() % uint64(i+1)
+		temp := xs[i]
+		xs[i] = xs[j]
+		xs[j] = temp
+	}
+}
+
+// Permutation returns a random permutation of the integers 0, ..., n-1, using a
+// Fisher-Yates shuffle.
+func Permutation(n uint64) []uint64 {
+	order := make([]uint64, n)
+	for i := uint64(0); i < n; i++ {
+		order[i] = uint64(i)
+	}
+	Shuffle(order)
+	return order
+}

--- a/std_core/std_core_test.go
+++ b/std_core/std_core_test.go
@@ -1,0 +1,72 @@
+package std_core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSumNoOverflow(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(true, SumNoOverflow(2, 3))
+	assert.Equal(true, SumNoOverflow(1<<64-2, 1))
+	assert.Equal(true, SumNoOverflow(1, 1<<64-2))
+
+	assert.Equal(false, SumNoOverflow(1<<64-1, 1))
+	assert.Equal(false, SumNoOverflow(1<<63, 1<<63))
+	assert.Equal(false, SumNoOverflow(1<<64-7, 26))
+}
+
+func TestSumAssumeNoOverflow(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(uint64(5), SumAssumeNoOverflow(2, 3))
+	assert.Equal(uint64(5), SumAssumeNoOverflow(5, 0))
+	assert.Equal(uint64(1<<64-1), SumAssumeNoOverflow(1<<64-2, 1))
+	assert.Panics(func() {
+		SumAssumeNoOverflow(1<<63, 1<<63)
+	})
+	assert.Panics(func() {
+		SumAssumeNoOverflow(1<<64-1, 2)
+	})
+}
+
+func TestMulAssumeNoOverflow(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(uint64(6), MulAssumeNoOverflow(2, 3))
+	assert.Equal(uint64(0), MulAssumeNoOverflow(0, 3))
+	assert.Equal(uint64(1<<64-1), MulAssumeNoOverflow(1<<32-1, 1<<32+1))
+	assert.Equal(uint64(1<<64-1), MulAssumeNoOverflow(1<<32+1, 1<<32-1))
+	assert.Panics(func() {
+		MulAssumeNoOverflow(1<<63, 2)
+	})
+	assert.Panics(func() {
+		MulAssumeNoOverflow(2, 1<<63)
+	})
+}
+
+func TestPermutation(t *testing.T) {
+	assert := assert.New(t)
+
+	order := Permutation(1)
+	assert.ElementsMatch(order, []uint64{0})
+
+	order = Permutation(2)
+	assert.ElementsMatch(order, []uint64{0, 1})
+
+	order = Permutation(5)
+	assert.ElementsMatch(order, []uint64{0, 1, 2, 3, 4})
+}
+
+func TestShuffle(t *testing.T) {
+	assert := assert.New(t)
+
+	xs := []uint64{}
+	Shuffle(xs)
+
+	xs = []uint64{1, 1, 1}
+	Shuffle(xs)
+	assert.Equal(xs, []uint64{1, 1, 1})
+}


### PR DESCRIPTION
This is to enable bootstrapping goose models: the goal is that a model can be implemented in Go and use std_core, then translated with goose and used for other (non-bootstrapped) code. This is especially useful for complex models like the channel one.