### PR TITLE
Add SignedSumAssumeNoOverflow

### DIFF
--- a/goose_std.go
+++ b/goose_std.go
@@ -1,8 +1,10 @@
 package std
 
 import (
+	"math"
 	"sync"
 
+	"github.com/goose-lang/primitive"
 	"github.com/goose-lang/std/std_core"
 )
 
@@ -23,6 +25,11 @@ func SumNoOverflow(x uint64, y uint64) bool {
 // *Use with care* - if the assumption is violated this function will panic.
 func SumAssumeNoOverflow(x uint64, y uint64) uint64 {
 	return std_core.SumAssumeNoOverflow(x, y)
+}
+
+func SignedSumAssumeNoOverflow(x int, y int) int {
+	primitive.Assume((y >= 0 && x <= math.MaxInt-y) || (y < 0 && x >= math.MinInt-y))
+	return x + y
 }
 
 // BytesEqual returns if the two byte slices are equal.

--- a/goose_std_test.go
+++ b/goose_std_test.go
@@ -1,6 +1,7 @@
 package std
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,18 @@ func TestAssert(t *testing.T) {
 	assert.Panics(t, func() {
 		Assert(false)
 	})
+}
+
+func TestSignedSumAssumeNoOverflow(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(int(3), SignedSumAssumeNoOverflow(1, 2))
+	assert.Equal(int(-3), SignedSumAssumeNoOverflow(-1, -2))
+	assert.Equal(int(-1), SignedSumAssumeNoOverflow(1, -2))
+	assert.Equal(int(math.MaxInt), SignedSumAssumeNoOverflow(math.MaxInt, 0))
+	assert.Equal(int(math.MinInt), SignedSumAssumeNoOverflow(math.MinInt, 0))
+	assert.Panics(func() { SignedSumAssumeNoOverflow(math.MaxInt, 1) })
+	assert.Panics(func() { SignedSumAssumeNoOverflow(math.MinInt, -1) })
+	assert.Panics(func() { SignedSumAssumeNoOverflow(1, math.MaxInt) })
 }
 
 func TestBytesEqual(t *testing.T) {

--- a/std_core/std_core.go
+++ b/std_core/std_core.go
@@ -3,7 +3,9 @@
 // It is used for bootstrapping goose.
 package std_core
 
-import "github.com/goose-lang/primitive"
+import (
+	"github.com/goose-lang/primitive"
+)
 
 // Returns true if x + y does not overflow
 func SumNoOverflow(x uint64, y uint64) bool {


### PR DESCRIPTION
The code for this is entirely different from `SumAssumeNoOverflow` (and depends on knowing the bounds on the input types) so I don't see a way to write a single generic function in Go.